### PR TITLE
fix: set the latest version tag from package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,12 @@ npm install --save-dev @nlib/changelog
 
 ## Usage
 
-Add the postversion scripts to your package.json.
+Add the [npm-version](https://docs.npmjs.com/cli/commands/npm-version) scripts to your package.json.
 
 ```json
 {
   "scripts": {
-    "postversion": "run-s postversion:*",
-    "postversion:changelog": "nlib-changelog --output CHANGELOG.md",
-    "postversion:add": "git add .",
-    "postversion:commit": "git commit --amend --no-edit"
+    "version": "nlib-changelog --output CHANGELOG.md && git add CHANGELOG.md"
   }
 }
 ```

--- a/src/getNodePackageVersion.mts
+++ b/src/getNodePackageVersion.mts
@@ -1,0 +1,23 @@
+/* eslint-disable no-console */
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { isObject } from '@nlib/typing';
+
+export const getNodePackageVersion = async (): Promise<string | null> => {
+  const jsonFilePath = new URL(
+    'package.json',
+    pathToFileURL(`${process.cwd()}${path.sep}`),
+  );
+  const stats = await fs.stat(jsonFilePath).catch(() => null);
+  if (stats && stats.isFile()) {
+    console.info('package.json found');
+    const json: unknown = JSON.parse(await fs.readFile(jsonFilePath, 'utf8'));
+    if (isObject(json) && typeof json.version === 'string') {
+      console.info(`version: ${json.version}`);
+      return json.version;
+    }
+    console.info('package.json found but version is not found');
+  }
+  return null;
+};


### PR DESCRIPTION
Amending a tagged commit pushes the tag aside in the history.